### PR TITLE
Consolidate package exports

### DIFF
--- a/src/recruitee_mcp/__init__.py
+++ b/src/recruitee_mcp/__init__.py
@@ -1,18 +1,15 @@
-"""Core package for the Recruitee MCP server."""
+"""Core package for the Recruitee MCP server, exposing the client, configuration, server, and HTTP helpers."""
 
+from .client import RecruiteeClient
+from .config import RecruiteeConfig
+from .http_server import create_http_server, serve_http
 from .server import JSONRPCError, RecruiteeMCPServer
-from .http_server import serve_http, create_http_server
 
 __all__ = [
     "JSONRPCError",
     "RecruiteeMCPServer",
+    "RecruiteeClient",
+    "RecruiteeConfig",
     "serve_http",
     "create_http_server",
 ]
-"""Recruitee MCP server package."""
-
-from .client import RecruiteeClient
-from .config import RecruiteeConfig
-from .server import RecruiteeMCPServer
-
-__all__ = ["RecruiteeClient", "RecruiteeConfig", "RecruiteeMCPServer"]


### PR DESCRIPTION
## Summary
- collapse duplicated module initialization content into a single docstring, import block, and export list
- ensure the package exports include the client, configuration, server, and HTTP helpers without redefining `__all__`

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68d173c20384832b86cdc7da6413fbec