### PR TITLE
Add HTTP health check endpoint

### DIFF
--- a/src/recruitee_mcp/http_server.py
+++ b/src/recruitee_mcp/http_server.py
@@ -16,6 +16,7 @@ LOGGER = logging.getLogger(__name__)
 
 DEFAULT_HTTP_PORT = 8080
 HTTP_PORT_ENV_VAR = "RECRUITEE_HTTP_PORT"
+HEALTH_CHECK_PATH = "/health"
 
 
 class ThreadingHTTPServer(ThreadingMixIn, HTTPServer):
@@ -84,6 +85,10 @@ def _create_handler(mcp_server: RecruiteeMCPServer) -> Type[BaseHTTPRequestHandl
             self._write_json_response(response_payload)
 
         def do_GET(self) -> None:  # noqa: N802 - required signature
+            if self.path == HEALTH_CHECK_PATH:
+                self._write_json_response({"status": "ok"})
+                return
+
             self.send_error(HTTPStatus.METHOD_NOT_ALLOWED, "Only POST is supported")
 
         def _dispatch_request(self, payload: Any) -> dict[str, Any]:
@@ -145,6 +150,7 @@ def serve_http(
 __all__ = [
     "DEFAULT_HTTP_PORT",
     "HTTP_PORT_ENV_VAR",
+    "HEALTH_CHECK_PATH",
     "ThreadingHTTPServer",
     "create_http_server",
     "serve_http",

--- a/tests/test_http_server.py
+++ b/tests/test_http_server.py
@@ -4,7 +4,7 @@ from urllib import request
 
 import pytest
 
-from recruitee_mcp.http_server import create_http_server
+from recruitee_mcp.http_server import HEALTH_CHECK_PATH, create_http_server
 from recruitee_mcp.server import RecruiteeMCPServer
 
 
@@ -56,3 +56,15 @@ def test_http_server_parse_error(http_server):
     response = _post_json(http_server, b"not-json")
     assert response["error"]["code"] == -32700
     assert response["id"] is None
+
+
+def test_http_server_health_check(http_server):
+    host, port = http_server.server_address[:2]
+    url = f"http://{host}:{port}{HEALTH_CHECK_PATH}"
+    with request.urlopen(url, timeout=2) as response:
+        assert response.status == 200
+        assert response.headers.get("Content-Type") == "application/json"
+        body = response.read().decode("utf-8")
+
+    payload = json.loads(body)
+    assert payload == {"status": "ok"}


### PR DESCRIPTION
## Summary
- add a /health endpoint that returns a JSON OK response for GET requests
- reuse the existing JSON response helper to send the health payload
- cover the health check route with a new HTTP server test

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_b_68d18e394254832ba1ad3ff95ef24623