### PR TITLE
Expose SearchFilters in package exports

### DIFF
--- a/src/recruitee_mcp/__init__.py
+++ b/src/recruitee_mcp/__init__.py
@@ -1,6 +1,6 @@
 """Core package for the Recruitee MCP server, exposing the client, configuration, server, and HTTP helpers."""
 
-from .client import RecruiteeClient
+from .client import RecruiteeClient, SearchFilters
 from .config import RecruiteeConfig
 from .http_server import create_http_server, serve_http
 from .server import JSONRPCError, RecruiteeMCPServer
@@ -9,7 +9,7 @@ __all__ = [
     "JSONRPCError",
     "RecruiteeMCPServer",
     "RecruiteeClient",
-    "SearchFilters"
+    "SearchFilters",
     "RecruiteeConfig",
     "serve_http",
     "create_http_server",


### PR DESCRIPTION
## Summary
- import `SearchFilters` from the package client module so it can be re-exported
- separate the `SearchFilters` and `RecruiteeConfig` entries in `__all__`

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68d29d7b8450832ba3a0cb8e9fa3cf77