### PR TITLE
Fix RecruiteeClient relative import

### DIFF
--- a/src/recruitee_mcp/mcp_server.py
+++ b/src/recruitee_mcp/mcp_server.py
@@ -8,7 +8,7 @@ from typing import Any, Dict, Optional, List, Mapping
 from mcp.server.fastmcp import FastMCP, Context
 from mcp.server.session import ServerSession
 
-from client import RecruiteeClient  # adjust import if your package layout differs
+from .client import RecruiteeClient  # adjust import if your package layout differs
 
 COMPANY_ID = os.getenv("RECRUITEE_COMPANY_ID")
 API_TOKEN = os.getenv("RECRUITEE_API_TOKEN")


### PR DESCRIPTION
## Summary
- update the MCP server module to import RecruiteeClient via a relative import so the package resolves correctly when run as a module

## Testing
- PYTHONPATH=src python -m recruitee_mcp.mcp_server *(fails: ModuleNotFoundError: No module named 'mcp')*

------
https://chatgpt.com/codex/tasks/task_b_68d29e46654c832baa29bcf6a088ec60