### PR TITLE
Add optional FastMCP dependency extra

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,19 @@ echo '{"jsonrpc": "2.0", "id": 1, "method": "ping"}' | recruitee-mcp --stdio
 
 This mode remains opt-in, while the default behaviour continues to be the HTTP transport described above.
 
+### FastMCP tooling
+
+The optional `recruitee_mcp.mcp_server` module relies on the
+[`mcp`](https://github.com/modelcontextprotocol/python-sdk) package. Install the
+extra dependencies to enable the FastMCP tools and streamable HTTP endpoints:
+
+```bash
+pip install "recruitee-mcp[fastmcp]"
+```
+
+If the dependencies are missing, importing the module will raise a descriptive
+error with the same installation hint.
+
 ## Development
 
 Install the project in editable mode and run the tests via `pytest`:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,9 @@ dependencies = []
 dev = [
   "pytest"
 ]
+fastmcp = [
+  "mcp[fastmcp]"
+]
 
 [project.scripts]
 recruitee-mcp-server = "recruitee_mcp.main:main"

--- a/src/recruitee_mcp/mcp_server.py
+++ b/src/recruitee_mcp/mcp_server.py
@@ -5,8 +5,13 @@ import os
 import asyncio
 from typing import Any, Dict, Optional, List, Mapping
 
-from mcp.server.fastmcp import FastMCP, Context
-from mcp.server.session import ServerSession
+try:  # pragma: no cover - exercised only when FastMCP extra installed
+    from mcp.server.fastmcp import FastMCP
+except ImportError as exc:  # pragma: no cover - clearer guidance for optional dependency
+    raise ImportError(
+        "FastMCP support requires the optional 'fastmcp' dependencies. "
+        "Install them with `pip install \"recruitee-mcp[fastmcp]\"`."
+    ) from exc
 
 from .client import RecruiteeClient  # adjust import if your package layout differs
 


### PR DESCRIPTION
## Summary
- add a `fastmcp` optional dependency that installs `mcp[fastmcp]`
- guard the FastMCP import with a helpful error message when the extra is missing
- document how to install the optional FastMCP requirements

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68d29f59e988832b85fb90230d3b180f