### PR TITLE
Update MCP protocol version

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,9 @@ Once the manifests are configured, you can apply updates at any time with
 `kubectl apply -f k8s/` to sync all resources in a single command.
 # Recruitee MCP
 
-This repository contains a minimal reference implementation of the Recruitee Model Context Protocol (MCP) server.
+This repository contains a minimal reference implementation of the Recruitee Model Context Protocol (MCP) server. It
+announces compliance with MCP protocol version 0.5 so it interoperates with current clients that target the published
+specification.
 
 ## Running the server
 

--- a/src/recruitee_mcp/server.py
+++ b/src/recruitee_mcp/server.py
@@ -15,6 +15,11 @@ from .client import (
     RecruiteeError,
 )
 
+try:  # pragma: no cover - only exercised when optional dependency is present
+    from mcp.server.constants import PROTOCOL_VERSION as MCP_PROTOCOL_VERSION
+except (ImportError, AttributeError):  # pragma: no cover - executed in minimal install
+    MCP_PROTOCOL_VERSION = "0.5"
+
 LOGGER = logging.getLogger(__name__)
 
 JsonDict = Dict[str, Any]
@@ -247,7 +252,7 @@ class RecruiteeMCPServer:
 
     def _handle_initialize(self) -> JsonDict:
         return {
-            "protocolVersion": "0.1",
+            "protocolVersion": MCP_PROTOCOL_VERSION,
             "serverInfo": {
                 "name": "recruitee-mcp",
                 "version": "0.1.0",

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock
 
-from recruitee_mcp.server import RecruiteeMCPServer
+from recruitee_mcp.server import MCP_PROTOCOL_VERSION, RecruiteeMCPServer
 
 
 def build_server() -> tuple[RecruiteeMCPServer, MagicMock]:
@@ -21,6 +21,7 @@ def build_server() -> tuple[RecruiteeMCPServer, MagicMock]:
 def test_initialize_response_contains_capabilities() -> None:
     server, _ = build_server()
     response = server._dispatch({"jsonrpc": "2.0", "id": 1, "method": "initialize"})
+    assert response["result"]["protocolVersion"] == MCP_PROTOCOL_VERSION
     assert response["result"]["serverInfo"]["name"] == "recruitee-mcp"
     assert response["result"]["capabilities"]["tools"]["call"] is True
 


### PR DESCRIPTION
## Summary
- update the MCP initialize handshake to report protocol version 0.5, using the SDK constant when available
- extend the initialize test to assert the negotiated protocol version
- document that the server now advertises MCP protocol version 0.5

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68d2a92bb6a8832ba4809ad9c56377dd