### PR TITLE
Add list_jobs helper delegating to list_offers

### DIFF
--- a/src/recruitee_mcp/client.py
+++ b/src/recruitee_mcp/client.py
@@ -105,6 +105,34 @@ class RecruiteeClient:
 
         return self._request("GET", "offers", params=params)
 
+    def list_jobs(
+        self,
+        *,
+        state: str | None = None,
+        limit: int | None = None,
+        include_description: bool = False,
+        scope: str | None = None,
+        view_mode: str | None = None,
+        offset: int | None = None,
+    ) -> Mapping[str, Any]:
+        """
+        Alias for :meth:`list_offers` using job-centric terminology.
+
+        The Recruitee API models public listings as "offers", but many callers
+        use "jobs" interchangeably. This helper mirrors
+        :meth:`list_offers` so downstream code can remain semantically
+        consistent while issuing the same request.
+        """
+
+        return self.list_offers(
+            state=state,
+            limit=limit,
+            include_description=include_description,
+            scope=scope,
+            view_mode=view_mode,
+            offset=offset,
+        )
+
     def get_offer(self, offer_id: int | str) -> Mapping[str, Any]:
         """Return the JSON representation for a single offer."""
         return self._request("GET", f"offers/{offer_id}")

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -32,7 +32,11 @@ class DummyResponse:
 
 
 def test_list_offers_builds_correct_request() -> None:
-    client = RecruiteeClient(company_id="acme", api_token="token-123")
+    client = RecruiteeClient(
+        company_id="acme",
+        api_token="token-123",
+        base_url="https://api.recruitee.com",
+    )
 
     def fake_urlopen(request, timeout):
         assert request.full_url == "https://api.recruitee.com/c/acme/offers?scope=published&limit=5"
@@ -47,8 +51,41 @@ def test_list_offers_builds_correct_request() -> None:
     assert response == {"offers": []}
 
 
+def test_list_jobs_delegates_to_list_offers() -> None:
+    client = RecruiteeClient(company_id="acme")
+
+    with patch.object(
+        RecruiteeClient,
+        "list_offers",
+        return_value={"offers": ["job"]},
+    ) as mock_list_offers:
+        response = client.list_jobs(
+            state="published",
+            limit=10,
+            include_description=True,
+            scope="active",
+            view_mode="brief",
+            offset=5,
+        )
+
+    assert response == {"offers": ["job"]}
+    mock_list_offers.assert_called_once_with(
+        state="published",
+        limit=10,
+        include_description=True,
+        scope="active",
+        view_mode="brief",
+        offset=5,
+    )
+
+
 def test_create_candidate_serialises_payload() -> None:
-    client = RecruiteeClient(company_id="acme", api_token="secret", timeout=10)
+    client = RecruiteeClient(
+        company_id="acme",
+        api_token="secret",
+        timeout=10,
+        base_url="https://api.recruitee.com",
+    )
 
     def fake_urlopen(request, timeout):
         assert request.full_url == "https://api.recruitee.com/c/acme/candidates"


### PR DESCRIPTION
## Summary
- add a `list_jobs` convenience wrapper on `RecruiteeClient`
- extend the client tests to cover the new alias and align explicit base URLs for request assertions

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68d309cdd1c0832b9b99b42f80333397