### PR TITLE
Rename search_offers tool to list_offers

### DIFF
--- a/src/recruitee_mcp/client.py
+++ b/src/recruitee_mcp/client.py
@@ -48,7 +48,7 @@ class RecruiteeClient:
 
     company_id: str
     api_token: str | None = None
-    base_url: str = "https://openvpn.recruitee.com"
+    base_url: str = "https://api.recruitee.com"
     timeout: float = 30.0
 
     @classmethod

--- a/src/recruitee_mcp/config.py
+++ b/src/recruitee_mcp/config.py
@@ -12,7 +12,7 @@ class RecruiteeConfig:
 
     company_id: str
     api_token: str | None = None
-    base_url: str = "https://openvpn.recruitee.com"
+    base_url: str = "https://api.recruitee.com"
     timeout: float = 30.0
 
     @classmethod

--- a/src/recruitee_mcp/main.py
+++ b/src/recruitee_mcp/main.py
@@ -45,7 +45,7 @@ def _create_parser() -> argparse.ArgumentParser:
     parser.add_argument("--api-token", help="Recruitee API token", default=None)
     parser.add_argument(
         "--base-url",
-        help="Override the Recruitee API base URL (defaults to https://openvpn.recruitee.com)",
+        help="Override the Recruitee API base URL (defaults to https://api.recruitee.com)",
         default=None,
     )
     parser.add_argument(

--- a/src/recruitee_mcp/mcp_server.py
+++ b/src/recruitee_mcp/mcp_server.py
@@ -17,7 +17,7 @@ from .client import RecruiteeClient  # adjust import if your package layout diff
 
 COMPANY_ID = os.getenv("RECRUITEE_COMPANY_ID")
 API_TOKEN = os.getenv("RECRUITEE_API_TOKEN")
-BASE_URL = os.getenv("RECRUITEE_BASE_URL", "https://openvpn.recruitee.com")
+BASE_URL = os.getenv("RECRUITEE_BASE_URL", "https://api.recruitee.com")
 
 if not COMPANY_ID or not API_TOKEN:
     raise RuntimeError(

--- a/src/recruitee_mcp/server.py
+++ b/src/recruitee_mcp/server.py
@@ -55,8 +55,8 @@ class RecruiteeMCPServer:
     def __init__(self, client: RecruiteeClient | None = None):
         self._client: RecruiteeClient | None = client
         self._tools: Dict[str, _Tool] = {
-            "search_offers": _Tool(
-                name="search_offers",
+            "list_offers": _Tool(
+                name="list_offers",
                 description="List job offers for the company.",
                 handler=self._tool_search_offers,
                 schema={

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -61,6 +61,34 @@ def test_call_tool_dispatches_to_client() -> None:
     assert response["result"]["content"][0]["data"]["candidate"]["id"] == 1
 
 
+def test_list_tools_includes_list_offers() -> None:
+    server, _ = build_server()
+    response = server._dispatch({"jsonrpc": "2.0", "id": 5, "method": "list_tools"})
+    tool_names = {tool["name"] for tool in response["result"]["tools"]}
+    assert "list_offers" in tool_names
+
+
+def test_call_tool_list_offers_invokes_client() -> None:
+    server, client = build_server()
+    response = server._dispatch(
+        {
+            "jsonrpc": "2.0",
+            "id": 6,
+            "method": "call_tool",
+            "params": {
+                "name": "list_offers",
+                "arguments": {"limit": 5},
+            },
+        }
+    )
+    client.list_offers.assert_called_once_with(
+        state=None,
+        limit=5,
+        include_description=False,
+    )
+    assert response["result"]["content"][0]["data"] == {"offers": []}
+
+
 def test_call_tool_missing_arguments_returns_error() -> None:
     server, _ = build_server()
     response = server._dispatch(


### PR DESCRIPTION
## Summary
- rename the JSON-RPC tool registration to list_offers so the server advertises and accepts the new name
- extend server tests to cover list_tools output and exercising call_tool/list_offers
- align the default Recruitee API base URL strings across client, config, CLI, and FastMCP server helpers

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68d30b64ef24832b88a07e59737ffe36