### PR TITLE
Map offer status to scope parameter

### DIFF
--- a/src/recruitee_mcp/client.py
+++ b/src/recruitee_mcp/client.py
@@ -86,9 +86,10 @@ class RecruiteeClient:
         """
         params: Dict[str, Any] = {}
 
-        # Back-compat: map your older `state` to the API's `scope`.
-        if state:
-            params["scope"] = state
+        # Canonical scope parameter, supporting both new (`status`) and legacy (`state`) names.
+        scope = status or state
+        if scope:
+            params["scope"] = scope
 
         if limit is not None:
             params["limit"] = limit
@@ -96,8 +97,6 @@ class RecruiteeClient:
             params["include_description"] = "true"
 
         # Canonical params:
-        if status:
-            params["status"] = status
         if view_mode:
             params["view_mode"] = view_mode
         if offset is not None:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -42,7 +42,7 @@ def test_list_offers_builds_correct_request() -> None:
         return DummyResponse({"offers": []})
 
     with patch("recruitee_mcp.client.urlopen", side_effect=fake_urlopen):
-        response = client.list_offers(state="published", limit=5)
+        response = client.list_offers(status="published", limit=5)
 
     assert response == {"offers": []}
 


### PR DESCRIPTION
## Summary
- update the client so list_offers maps both status and legacy state arguments to the scope query parameter expected by the API
- adjust the list_offers client test to exercise the new status parameter behaviour

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68d31465c528832b87b7f3ed545f0280