### PR TITLE
Add MCPO manifest metadata to HTTP transport

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,10 @@ To explicitly select the port via CLI instead of the environment variable:
 recruitee-mcp --port 9090
 ```
 
+The HTTP transport now advertises a [Model Context Protocol over HTTP (MCPO)](https://github.com/modelcontextprotocol)
+manifest at `/.well-known/mcp.json`. Clients that support MCPO discovery (including Open WebUI) can use the
+manifest to discover the JSON-RPC endpoint and available tools.
+
 ### Legacy stdio transport
 
 For backwards compatibility a stdio transport is still available. It can be enabled with the `--stdio` flag which causes

--- a/src/recruitee_mcp/http_server.py
+++ b/src/recruitee_mcp/http_server.py
@@ -18,7 +18,8 @@ LOGGER = logging.getLogger(__name__)
 DEFAULT_HTTP_PORT = 8080
 HTTP_PORT_ENV_VAR = "RECRUITEE_HTTP_PORT"
 HEALTH_CHECK_PATH = "/health"
-HANDSHAKE_PATHS = {"/", "/mcp"}
+HANDSHAKE_PATHS = {"/", "/mcp", "/openai-mcp"}
+MCPO_MANIFEST_PATH = "/.well-known/mcp.json"
 FAVICON_SVG = (
     "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 16 16\" "
     "fill=\"none\" stroke=\"#0f172a\" stroke-width=\"1.5\">"
@@ -27,19 +28,34 @@ FAVICON_SVG = (
 )
 
 
-def _handshake_payload() -> dict[str, Any]:
+def _handshake_payload(mcp_server: RecruiteeMCPServer) -> dict[str, Any]:
     """Return a descriptive payload for HTTP GET probes."""
 
+    protocol_description = mcp_server.describe_protocol()
     payload: dict[str, Any] = {
         "status": "ok",
         "name": "recruitee-mcp",
         "message": "Send POST requests with JSON-RPC 2.0 payloads to interact with the Recruitee MCP server.",
+        "protocol": protocol_description["protocol"],
+        "protocol_version": protocol_description["protocol_version"],
+        "capabilities": protocol_description["capabilities"],
+        "endpoints": {
+            "jsonrpc": {"path": "/"},
+        },
     }
 
     try:
         payload["version"] = metadata.version("recruitee-mcp")
     except metadata.PackageNotFoundError:  # pragma: no cover - metadata missing when running from source tree
-        pass
+        payload["version"] = None
+
+    if FastMCP is not None:  # pragma: no branch - conditional metadata only
+        payload["endpoints"].update(
+            {
+                "streamable_http": {"path": "/mcp"},
+                "sse": {"path": "/sse"},
+            }
+        )
 
     return payload
 
@@ -125,7 +141,11 @@ def _create_handler(mcp_server: RecruiteeMCPServer) -> Type[BaseHTTPRequestHandl
 
             normalized_path = self.path.rstrip("/") or "/"
             if normalized_path in HANDSHAKE_PATHS:
-                self._write_json_response(_handshake_payload())
+                self._write_json_response(_handshake_payload(mcp_server))
+                return
+
+            if normalized_path == MCPO_MANIFEST_PATH.rstrip("/"):
+                self._write_json_response(_handshake_payload(mcp_server))
                 return
 
             self.send_error(HTTPStatus.NOT_FOUND, "Unknown endpoint")
@@ -194,6 +214,7 @@ __all__ = [
     "create_http_server",
     "serve_http",
     "FAVICON_SVG",
+    "MCPO_MANIFEST_PATH",
 ]
 
 

--- a/src/recruitee_mcp/server.py
+++ b/src/recruitee_mcp/server.py
@@ -6,7 +6,7 @@ import json
 import logging
 import sys
 from dataclasses import dataclass
-from typing import Any, Callable, Dict, Mapping
+from typing import Any, Callable, Dict, Mapping, Sequence
 
 from .client import (
     RecruiteeAPIError,
@@ -148,6 +148,34 @@ class RecruiteeMCPServer:
                 },
             ),
         }
+
+    # ------------------------------------------------------------------
+    # Capability / metadata helpers
+    # ------------------------------------------------------------------
+    def describe_protocol(self) -> Dict[str, Any]:
+        """Return a descriptive payload about the server's MCP support."""
+
+        return {
+            "protocol": "model-context-protocol",
+            "protocol_version": MCP_PROTOCOL_VERSION,
+            "capabilities": {
+                "tools": self._tool_summaries(),
+                "resources": [],
+                "prompts": [],
+            },
+        }
+
+    def _tool_summaries(self) -> Sequence[Dict[str, Any]]:
+        summaries = []
+        for tool in sorted(self._tools.values(), key=lambda item: item.name):
+            summaries.append(
+                {
+                    "name": tool.name,
+                    "description": tool.description,
+                    "schema": tool.schema,
+                }
+            )
+        return summaries
 
     # ------------------------------------------------------------------
     # JSON-RPC entry points

--- a/tests/test_http_server.py
+++ b/tests/test_http_server.py
@@ -116,6 +116,18 @@ def test_http_server_mcpo_manifest(http_server):
     _assert_handshake_payload(payload)
 
 
+def test_http_server_mcpo_manifest_with_query_string(http_server):
+    host, port = http_server.server_address[:2]
+    url = f"http://{host}:{port}{MCPO_MANIFEST_PATH}?ts=123"
+    with request.urlopen(url, timeout=2) as response:
+        assert response.status == 200
+        assert response.headers.get("Content-Type") == "application/json"
+        body = response.read().decode("utf-8")
+
+    payload = json.loads(body)
+    _assert_handshake_payload(payload)
+
+
 def test_http_server_favicon(http_server):
     host, port = http_server.server_address[:2]
     url = f"http://{host}:{port}/favicon.svg"

--- a/tests/test_http_server.py
+++ b/tests/test_http_server.py
@@ -8,8 +8,10 @@ from recruitee_mcp.http_server import (
     FAVICON_SVG,
     HEALTH_CHECK_PATH,
     HANDSHAKE_PATHS,
+    MCPO_MANIFEST_PATH,
     create_http_server,
 )
+from recruitee_mcp.server import MCP_PROTOCOL_VERSION
 from recruitee_mcp.server import RecruiteeMCPServer
 
 
@@ -85,9 +87,33 @@ def test_http_server_handshake(http_server, path):
         body = response.read().decode("utf-8")
 
     payload = json.loads(body)
+    _assert_handshake_payload(payload)
+
+
+def _assert_handshake_payload(payload: dict) -> None:
     assert payload["status"] == "ok"
     assert payload["name"] == "recruitee-mcp"
+    assert payload["protocol"] == "model-context-protocol"
+    assert payload["protocol_version"] == MCP_PROTOCOL_VERSION
     assert "message" in payload
+    assert payload["capabilities"]["resources"] == []
+    assert payload["capabilities"]["prompts"] == []
+    tools = payload["capabilities"]["tools"]
+    assert isinstance(tools, list) and tools
+    assert payload["endpoints"]["jsonrpc"] == {"path": "/"}
+    assert "version" in payload
+
+
+def test_http_server_mcpo_manifest(http_server):
+    host, port = http_server.server_address[:2]
+    url = f"http://{host}:{port}{MCPO_MANIFEST_PATH}"
+    with request.urlopen(url, timeout=2) as response:
+        assert response.status == 200
+        assert response.headers.get("Content-Type") == "application/json"
+        body = response.read().decode("utf-8")
+
+    payload = json.loads(body)
+    _assert_handshake_payload(payload)
 
 
 def test_http_server_favicon(http_server):


### PR DESCRIPTION
## Summary
- expose a Model Context Protocol over HTTP manifest describing JSON-RPC endpoints and tool metadata
- extend the HTTP handshake payloads to include protocol and capability information for MCPO clients
- document the new `/.well-known/mcp.json` discovery endpoint and cover it with tests

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_b_68d55db19c9c832baccb51676d72bcab